### PR TITLE
feat: Adding --list-only argument to export a list of active images

### DIFF
--- a/auto_scan.py
+++ b/auto_scan.py
@@ -106,11 +106,10 @@ def get_active_containers(lw_client, container_registry_domains, start_time, end
 
     return active_containers
 
+
 def list_containers(containers):
     for container in containers:
-        # Parse the container registry and repository
-        container_registry, container_repository = container['REPO'].split('/', 1)
-        print(f'{container_registry}/{container_repository}:{container["TAG"]}')
+        print(f'{container["REPO"]}:{container["TAG"]}')
 
 
 def initiate_container_scan(lw_client, container_registry, container_repository, container_tag):
@@ -149,8 +148,8 @@ def scan_containers(lw_client, containers, scanned_container_cache):
             print(f'Scanning {container_registry}/{container_repository} with tag "{container["TAG"]}" ({i})')
 
             executor_tasks.append(executor.submit(
-                    initiate_container_scan, lw_client, container_registry, container_repository, container['TAG']
-                ))
+                initiate_container_scan, lw_client, container_registry, container_repository, container['TAG']
+            ))
 
             i += 1
 
@@ -171,12 +170,10 @@ def main(args):
 
     if args.debug:
         logging.basicConfig(level=logging.DEBUG)
-    
     if args.days:
         days_back = args.days
     else:
         days_back = 1
-                
     # Build start/end times
     current_time = datetime.now(timezone.utc)
     start_time = current_time - timedelta(hours=args.hours, days=days_back)
@@ -204,7 +201,6 @@ def main(args):
     else:
         # Scan all the containers
         scan_containers(lw_client, active_containers, scanned_container_cache, args.inline)
-    
 
 if __name__ == '__main__':
 

--- a/auto_scan.py
+++ b/auto_scan.py
@@ -106,6 +106,12 @@ def get_active_containers(lw_client, container_registry_domains, start_time, end
 
     return active_containers
 
+def list_containers(containers):
+    for container in containers:
+        # Parse the container registry and repository
+        container_registry, container_repository = container['REPO'].split('/', 1)
+        print(f'{container_registry}/{container_repository}:{container["TAG"]}')
+
 
 def initiate_container_scan(lw_client, container_registry, container_repository, container_tag):
     if container_registry == 'docker.io':
@@ -121,7 +127,6 @@ def initiate_container_scan(lw_client, container_registry, container_repository,
         message = f'Failed to scan container {container_registry}/{container_repository} with tag ' \
             f'{container_tag}". Error: {e}'
         logging.warning(message)
-
 
 def scan_containers(lw_client, containers, scanned_container_cache):
     print(f'Container Count: {len(containers)}')
@@ -144,8 +149,8 @@ def scan_containers(lw_client, containers, scanned_container_cache):
             print(f'Scanning {container_registry}/{container_repository} with tag "{container["TAG"]}" ({i})')
 
             executor_tasks.append(executor.submit(
-                initiate_container_scan, lw_client, container_registry, container_repository, container['TAG']
-            ))
+                    initiate_container_scan, lw_client, container_registry, container_repository, container['TAG']
+                ))
 
             i += 1
 
@@ -166,12 +171,12 @@ def main(args):
 
     if args.debug:
         logging.basicConfig(level=logging.DEBUG)
-
+    
     if args.days:
         days_back = args.days
     else:
         days_back = 1
-
+                
     # Build start/end times
     current_time = datetime.now(timezone.utc)
     start_time = current_time - timedelta(hours=args.hours, days=days_back)
@@ -194,9 +199,12 @@ def main(args):
     # Query for active containers across registries
     active_containers = get_active_containers(lw_client, container_registry_domains, start_time, end_time)
 
-    # Scan all the containers
-    scan_containers(lw_client, active_containers, scanned_container_cache)
-
+    if args.listOnly:
+        list_containers(active_containers)
+    else:
+        # Scan all the containers
+        scan_containers(lw_client, active_containers, scanned_container_cache, args.inline)
+    
 
 if __name__ == '__main__':
 
@@ -216,6 +224,7 @@ if __name__ == '__main__':
     parser.add_argument('--hours', default=0, type=int, help='The number of hours in which to search for active containers')
     parser.add_argument('--registry', help='The container registry domain for which to issue scans')
     parser.add_argument('--rescan', dest='rescan', action='store_true')
+    parser.add_argument('--list-only', dest='listOnly', action='store_true')
     parser.add_argument('-d', '--daemon', action='store_true')
     parser.add_argument('--debug', action='store_true')
     args = parser.parse_args()


### PR DESCRIPTION
This pull request adds a feature `--list-only` to the auto_scan.py script.  This flag will export a list of active images without triggering a scan.  This is useful for customers who may not have a particular registry integration in Lacework and would like to automate image scans via the inline scanner based on what's currently running in their environment.  

Example output:

```
❯ python auto_scan.py --registry gcr.io --list-only
Fetching container assessments since "2021-12-15T22:46:44Z"...
Previously Assessed Container Count: 10
Building container assessment cache...
Fetching active containers for gcr.io...
Found 11 active containers for gcr.io...
gcr.io/bank-of-anthos/frontend:v0.5.0
gcr.io/bank-of-anthos/contacts:v0.5.0
gcr.io/bank-of-anthos/ledger-db:v0.5.0
gcr.io/bank-of-anthos/loadgenerator:v0.5.0
gcr.io/gke-release/istio/proxyv2:1.6.14-gke.1
gcr.io/bank-of-anthos/accounts-db:v0.5.0
gcr.io/bank-of-anthos/transactionhistory:v0.5.0
gcr.io/bank-of-anthos/balancereader:v0.5.0
gcr.io/gke-release/istio/pilot:1.6.14-gke.1
gcr.io/bank-of-anthos/userservice:v0.5.0
gcr.io/bank-of-anthos/ledgerwriter:v0.5.0
```
