### PR TITLE
Introduce Support to Use Inline Scanner 

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ If you wish to run this script continuously, there is an example Kubernetes mani
 |       | `--api-key`       | `None`  | The Lacework API key to use                                                 |
 |       | `--api-secret`    | `None`  | The Lacework API secret to use                                              |
 | `-p`  | `--profile`       | `None`  | The Lacework CLI profile to use                                             |
-|       | `--proxy-scanner` | `None`  | The address of a Lacework proxy scanner (http(s)://<address>:<port>)        |
+|       | `--proxy-scanner` | `None`  | The address of a Lacework proxy scanner: http(s)://[address]:[port]         |
 |       | `--days`          | `None`  | The number of days in which to search for active containers                 |
 |       | `--hours`         | `0`     | The number of hours in which to search for active containers                |
 |       | `--registry`      | `None`  | The container registry domain(s) for which to issue scans (comma separated) |

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ The script can also read the standard Lacework CLI environment variables for aut
 If cloning this repository, rather than using a container, you can run the script with the following usage:
 
 ```bash
-usage: argmark [-h] [--account ACCOUNT] [--subaccount SUBACCOUNT] [--api-key API_KEY] [--api-secret API_SECRET] [-p PROFILE] [--proxy-scanner PROXY_SCANNER] [--days DAYS] [--hours HOURS] [--registry REGISTRY] [--rescan] [--list-only] [-d] [--debug]
+usage: ./auto-scan.py [-h] [--account ACCOUNT] [--subaccount SUBACCOUNT] [--api-key API_KEY] [--api-secret API_SECRET] [-p PROFILE] [--proxy-scanner PROXY_SCANNER] [--days DAYS] [--hours HOURS] [--registry REGISTRY] [--rescan] [--list-only] [-d] [--debug]
 ```
 
 ### Kubernetes Manifest

--- a/auto_scan.py
+++ b/auto_scan.py
@@ -267,7 +267,7 @@ if __name__ == '__main__':
         '--proxy-scanner',
         default=None,
         type=str,
-        help='The address of a Lacework proxy scanner (http(s)://<address>:<port>)'
+        help='The address of a Lacework proxy scanner: http(s)://[address]:[port]'
     )
     parser.add_argument(
         '--days',


### PR DESCRIPTION
Problem: The current implementation will only submit scans for registries which are backed by the platform scanner. This leaves many public images unscanned in customer environments. 

Solution: Introduce flags to enable the use of the inline scanner as a means to add additional scan coverage. 