### PR TITLE
fix: switching de-dupe logic to use image ID rather than tag

### DIFF
--- a/auto_scan.py
+++ b/auto_scan.py
@@ -484,7 +484,7 @@ def main(args):
     else:
         days_back = 1
 
-    subaccounts = [args.subaccount]
+    subaccounts = [lw_client._subaccount]
 
     if args.org_level:
         lw_client.set_org_level_access(True)


### PR DESCRIPTION
Switching the de-duplication logic to use Image ID rather than tag, as it's much more definitive as to whether we've scanned the exact image.  Also, I've opened an Aha to have the agent collect the image digest, so that we can pull the exact version of a given image for scanning.