### PR TITLE
bug: malformed cache kills processing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,7 @@ logs/
 # Virtual Environments
 .venv/
 venv/
+env/
 
 # Test artifacts
 .cache/

--- a/auto_scan.py
+++ b/auto_scan.py
@@ -213,7 +213,14 @@ def load_failed_scans():
     if os.path.isfile(FAILED_SCAN_CACHE):
         # Open the CONFIG_FILE and load it
         with open(FAILED_SCAN_CACHE, 'r') as failed_scan_cache:
-            return json.loads(failed_scan_cache.read())
+            try:
+                return json.loads(failed_scan_cache.read())
+            except Exception as err:
+                # If this fails, it's likely due to an old cache before expirations were implemented
+                # Rebuild the cache
+                logger.warning(f'Error loading failed scan cache: {err}. Clearing failed scan cache...')
+                os.remove(FAILED_SCAN_CACHE)
+                return {}
     else:
         return {}
 

--- a/auto_scan.py
+++ b/auto_scan.py
@@ -496,10 +496,10 @@ def main(args):
     if args.org_level and not args.auto_integrate_inline_scanner and (args.inline_scanner or args.inline_scanner_access_token):
         logger.error('Currently the --org-level argument is only compatible with auto-integrated Inline Scanner.')
         exit()
-    
+
     if args.proxy_scanner and not args.registry:
-        logger.error('--proxy-scanner passed without --registry configuration. Please specify both arguments to execute proxy scans.')
-        exit() 
+        logger.error('--proxy-scanner passed without --registry flag. Please specify both arguments to execute proxy scans.')
+        exit()
 
     try:
         lw_client = LaceworkClient(

--- a/auto_scan.py
+++ b/auto_scan.py
@@ -496,6 +496,10 @@ def main(args):
     if args.org_level and not args.auto_integrate_inline_scanner and (args.inline_scanner or args.inline_scanner_access_token):
         logger.error('Currently the --org-level argument is only compatible with auto-integrated Inline Scanner.')
         exit()
+    
+    if args.proxy_scanner and not args.registry:
+        logger.error('--proxy-scanner passed without --registry configuration. Please specify both arguments to execute proxy scans.')
+        exit() 
 
     try:
         lw_client = LaceworkClient(

--- a/auto_scan.py
+++ b/auto_scan.py
@@ -497,6 +497,10 @@ def main(args):
         logger.error('Currently the --org-level argument is only compatible with auto-integrated Inline Scanner.')
         exit()
 
+    if (args.inline_scanner or args.inline_scanner_access_token) and args.registry and not args.inline_scanner_only:
+        logger.warning('Inline scanner in use with --registry specified. Registries will be scanned using platform scanner.')
+        logger.warning('Use --inline-scanner-only to scan these target registries using the inline scanner')
+
     if args.proxy_scanner and not args.registry:
         logger.error('--proxy-scanner passed without --registry flag. Please specify both arguments to execute proxy scans.')
         exit()

--- a/auto_scan.py
+++ b/auto_scan.py
@@ -491,19 +491,27 @@ def scan_containers(lw_client, container_scan_queue, registry_domains, args):
         logger.info('Scan Errors:\n' + tabulate(scan_errors, headers='keys'))
 
 
-def main(args):
-
+def assess_arguments(args):
     if args.org_level and not args.auto_integrate_inline_scanner and (args.inline_scanner or args.inline_scanner_access_token):
         logger.error('Currently the --org-level argument is only compatible with auto-integrated Inline Scanner.')
         exit()
 
-    if (args.inline_scanner or args.inline_scanner_access_token) and args.registry and not args.inline_scanner_only:
-        logger.warning('Inline scanner in use with --registry specified. Registries will be scanned using platform scanner.')
-        logger.warning('Use --inline-scanner-only to scan these target registries using the inline scanner')
+    # if we're using an inline scanner flag, and have specified registries, but have not specified inline-scanner-only
+    if (
+            (args.inline_scanner or args.inline_scanner_access_token or args.auto_integrate_inline_scanner)
+            and args.registry
+            and not args.inline_scanner_only
+       ):
+        logger.warning('Inline scanner in use with --registry specified. Images from registries will be scanned using platform scanner. Use --inline-scanner-only to scan images from these target registries using the inline scanner')  # noqa 
 
     if args.proxy_scanner and not args.registry:
         logger.error('--proxy-scanner passed without --registry flag. Please specify both arguments to execute proxy scans.')
         exit()
+
+
+def main(args):
+
+    assess_arguments(args)
 
     try:
         lw_client = LaceworkClient(


### PR DESCRIPTION
A customer ended up in a state with a malformed JSON payload in the cache. This PR introduces handling (and purging) of a malformed cache. 

A separate customer was trying to use the `--proxy-scanner` flag without the `--registry` flag, which resulted in no images being scanned. Added an explicit warning and exit for that configuration. 