### PR TITLE
fix: Updated logic to better handle Inline Scanner assessments

### DIFF
--- a/auto_scan.py
+++ b/auto_scan.py
@@ -56,7 +56,6 @@ def build_container_assessment_cache(lw_client, start_time, end_time):
         repository = scanned_container['IMAGE_REPO']
         image_id = scanned_container['IMAGE_ID']
         # tags = scanned_container['IMAGE_TAGS']
-        
         # Images scanned by the inline already contains the registry name
         if repository.startswith(registry):
             qualified_repo = f'{repository}'.lstrip('/')

--- a/auto_scan.py
+++ b/auto_scan.py
@@ -56,8 +56,13 @@ def build_container_assessment_cache(lw_client, start_time, end_time):
         repository = scanned_container['IMAGE_REPO']
         image_id = scanned_container['IMAGE_ID']
         # tags = scanned_container['IMAGE_TAGS']
-
-        qualified_repo = f'{registry}/{repository}'.lstrip('/')
+        
+        # Images scanned by the inline already contains the registry name
+        if repository.startswith(registry):
+            qualified_repo = f'{repository}'.lstrip('/')
+        else:
+            qualified_repo = f'{registry}/{repository}'.lstrip('/')
+        
         qualified_repo = qualified_repo.replace('http://', '').replace('https://', '')
 
         if qualified_repo not in scanned_container_cache.keys():

--- a/auto_scan.py
+++ b/auto_scan.py
@@ -56,12 +56,13 @@ def build_container_assessment_cache(lw_client, start_time, end_time):
         repository = scanned_container['IMAGE_REPO']
         image_id = scanned_container['IMAGE_ID']
         # tags = scanned_container['IMAGE_TAGS']
+
         # Images scanned by the inline already contains the registry name
         if repository.startswith(registry):
-            qualified_repo = f'{repository}'.lstrip('/')
+            qualified_repo = f'{repository}'
         else:
-            qualified_repo = f'{registry}/{repository}'.lstrip('/')
-        
+            qualified_repo = f'{registry}/{repository}'
+        qualified_repo = qualified_repo.lstrip('/')
         qualified_repo = qualified_repo.replace('http://', '').replace('https://', '')
 
         if qualified_repo not in scanned_container_cache.keys():


### PR DESCRIPTION
In the images already scanned by the inline-scanner, the registry name is already included in the repository name:
eg:
./lw-scanner image evaluate ghcr.io/fluxcd/source-controller v0.21.2 --save

Gives:
% lacework vulnerability container list
  REGISTRY              REPOSITORY                   LAST SCAN         STATUS    CONTAINERS      VULNERABILITIES                                   IMAGE DIGEST                                
-----------+----------------------------------+----------------------+---------+------------+-----------------------+--------------------------------------------------------------------------
  ghcr.io    ghcr.io/fluxcd/source-controller   2022-07-15T07:53:59Z   Success   0            1 Critical 11 Fixable   sha256:80021394c1be9980f3c0ca41bca529edac2ed0a0d3d982cb1a45b62283c08e8e  

As a result the dedup function will not match, and the same image is scanned...