### PR TITLE
fix: excluding 'none' container repos from scanning

### DIFF
--- a/auto_scan.py
+++ b/auto_scan.py
@@ -755,5 +755,5 @@ if __name__ == '__main__':
         else:
             main(args)
     except Exception as e:
-        logger.error(e)
+        logger.error(e, exc_info=True)
         parser.print_help()

--- a/auto_scan.py
+++ b/auto_scan.py
@@ -85,6 +85,8 @@ def build_container_query(registry=None):
         if registry == 'index.docker.io':
             registry = 'docker.io'
         query_text += f" filter {{ starts_with(REPO, '{registry}') }}"
+    else:
+        query_text += " filter {{ REPO <> 'none' }}"
     query_text += ' return distinct {REPO, IMAGE_ID, TAG} }'
 
     logger.debug(f'LQL Query: {query_text}')

--- a/auto_scan.py
+++ b/auto_scan.py
@@ -86,7 +86,7 @@ def build_container_query(registry=None):
             registry = 'docker.io'
         query_text += f" filter {{ starts_with(REPO, '{registry}') }}"
     else:
-        query_text += " filter {{ REPO <> 'none' }}"
+        query_text += " filter { REPO <> 'none' }"
     query_text += ' return distinct {REPO, IMAGE_ID, TAG} }'
 
     logger.debug(f'LQL Query: {query_text}')


### PR DESCRIPTION
Updated LQL query to exclude container repositories that are `none` since we cannot scan them.