### PR TITLE
feat: create scan requests based on digest when possible

### DIFF
--- a/Dockerfile.dind
+++ b/Dockerfile.dind
@@ -1,6 +1,6 @@
 FROM python:3.10-slim
 
-ENV LW_SCANNER_VERSION=0.11.2
+ENV LW_SCANNER_VERSION=0.12.0
 
 RUN apt-get update && apt-get install -y \
     ca-certificates \


### PR DESCRIPTION
This PR will attempt to issue scans using the image digest when possible - falling back to the tag when digest is not available.  This allows us to target a specific image when customers are using an ephemeral tag like `latest` in their environment.