### PR TITLE
chore: bumping versions of dependencies

### DIFF
--- a/.github/workflows/python-test.yml
+++ b/.github/workflows/python-test.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.7", "3.8", "3.9", "3.10"]
+        python-version: ["3.8", "3.9", "3.10", "3.11"]
 
     steps:
       - uses: actions/checkout@v2

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.10-slim
+FROM python:3.11-slim
 
 RUN groupadd --gid 5000 user && useradd --home-dir /home/user --create-home --uid 5000 --gid 5000 --shell /bin/sh --skel /dev/null user
 USER user

--- a/Dockerfile.dind
+++ b/Dockerfile.dind
@@ -1,6 +1,6 @@
-FROM python:3.10-slim
+FROM python:3.11-slim
 
-ENV LW_SCANNER_VERSION=0.11.2
+ENV LW_SCANNER_VERSION=0.14.1
 
 RUN apt-get update && apt-get install -y \
     ca-certificates \


### PR DESCRIPTION
Bumping versions of Python and the Lacework Inline Scanner