### PR TITLE
chore: redirect docker images to lacework org

### DIFF
--- a/.github/workflows/docker-publish-dind.yml
+++ b/.github/workflows/docker-publish-dind.yml
@@ -20,8 +20,8 @@ jobs:
       LW_ACCOUNT_NAME: ${{ secrets.LW_ACCOUNT_NAME }}
       LW_SCANNER_SAVE_RESULTS: true
       LW_SCANNER_SCAN_LIBRARY_PACKAGES: true
-      DOCKER_REPO: alannix/container-auto-scan-inline
-      DOCKER_TEST_NAME: alannix/container-auto-scan-inline-test
+      DOCKER_REPO: lacework/container-auto-scan-inline
+      DOCKER_TEST_NAME: lacework/container-auto-scan-inline-test
     steps:
 
       - name: Checkout

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -20,8 +20,8 @@ jobs:
       LW_ACCOUNT_NAME: ${{ secrets.LW_ACCOUNT_NAME }}
       LW_SCANNER_SAVE_RESULTS: true
       LW_SCANNER_SCAN_LIBRARY_PACKAGES: true
-      DOCKER_REPO: alannix/container-auto-scan
-      DOCKER_TEST_NAME: alannix/container-auto-scan-test
+      DOCKER_REPO: lacework/container-auto-scan
+      DOCKER_TEST_NAME: lacework/container-auto-scan-test
     steps:
 
       - name: Checkout

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Lacework Auto Scanner
 
 ![Build Status](https://github.com/lacework-dev/container-auto-scan/actions/workflows/python-test.yml/badge.svg)
-![Docker Pulls](https://img.shields.io/docker/pulls/alannix/container-auto-scan)
+![Docker Pulls](https://img.shields.io/docker/pulls/lacework/container-auto-scan)
 
 The aim of this project is to make it simple to trigger vulnerability assessments for containers which are active in a Lacework account/organization.
 
@@ -22,7 +22,7 @@ The default "look-back" period is 1 day, but can be augmented with the `--days <
 The easiest way to run this script is by executing it as a container using Lacework API credentials provided from your Lacework CLI configuration:
 
 ```bash
-docker run -v ~/.lacework.toml:/home/user/.lacework.toml alannix/container-auto-scan
+docker run -v ~/.lacework.toml:/home/user/.lacework.toml lacework/container-auto-scan
 ```
 
 This will mount your Lacework CLI credentials into the container and execute the scan on the default profile. You can, of course, pass in a different profile with the `-p <profile>` argument as outlined [here](#user-content-arguments). Or you can provide credentials using the `--account`, `--subaccount`, `--api-key`, `--api-secret` arguments.
@@ -48,7 +48,7 @@ Due to permissions and dependency requirements for Docker-in-Docker, a new conta
 In order to run the Docker-in-Docker container, you'll execute the following:
 
 ```bash
-docker run -v ~/.lacework.toml:/root/.lacework.toml -v /var/run/docker.sock:/var/run/docker.sock alannix/container-auto-scan-inline --inline-scanner-access-token <SCANNER_ACCESS_TOKEN_HERE>
+docker run -v ~/.lacework.toml:/root/.lacework.toml -v /var/run/docker.sock:/var/run/docker.sock lacework/container-auto-scan-inline --inline-scanner-access-token <SCANNER_ACCESS_TOKEN_HERE>
 ```
 
 ### Inline Scanner Auto Integration
@@ -58,7 +58,7 @@ As of version `0.5` of this script, the Inline Scanner integration (and subseque
 This option is extra beneficial when paired with the `--org-level` argument, as all inline scanner integrations will be automatically generated across an entire Lacework organization.
 
 ```bash
-docker run -v ~/.lacework.toml:/root/.lacework.toml -v /var/run/docker.sock:/var/run/docker.sock alannix/container-auto-scan-inline --org-level --auto-integrate-inline-scanner
+docker run -v ~/.lacework.toml:/root/.lacework.toml -v /var/run/docker.sock:/var/run/docker.sock lacework/container-auto-scan-inline --org-level --auto-integrate-inline-scanner
 ```
 
 #### Things to Note

--- a/manifests/inline-scanner/deployment.yaml
+++ b/manifests/inline-scanner/deployment.yaml
@@ -25,7 +25,7 @@ spec:
         app: lacework-auto-scan
     spec:
       containers:
-      - image: alannix/container-auto-scan-inline:latest
+      - image: lacework/container-auto-scan-inline:latest
         name: lacework-auto-scan
         args: ["-d", "--inline-scanner"]
         env:

--- a/manifests/org-level-auto-integrated-scanner/deployment.yaml
+++ b/manifests/org-level-auto-integrated-scanner/deployment.yaml
@@ -24,7 +24,7 @@ spec:
         app: lacework-auto-scan
     spec:
       containers:
-      - image: alannix/container-auto-scan-inline:latest
+      - image: lacework/container-auto-scan-inline:latest
         name: lacework-auto-scan
         args: ["-d", "--auto-integrate-inline-scanner", "--org-level"]
         env:

--- a/manifests/platform-scanner/deployment.yaml
+++ b/manifests/platform-scanner/deployment.yaml
@@ -24,7 +24,7 @@ spec:
         app: lacework-auto-scan
     spec:
       containers:
-      - image: alannix/container-auto-scan:latest
+      - image: lacework/container-auto-scan:latest
         name: lacework-auto-scan
         args: ["-d"]
         env:


### PR DESCRIPTION
Jira: https://lacework.atlassian.net/browse/GROW-1501

<img src="https://media3.giphy.com/media/7SF5scGB2AFrgsXP63/giphy.gif"/>

New docker images:
* https://hub.docker.com/r/lacework/container-auto-scan
* https://hub.docker.com/r/lacework/container-auto-scan-inline

![Screen Shot 2023-03-28 at 11 57 02 AM](https://user-images.githubusercontent.com/5712253/228339822-0f092b9c-18a9-4f3a-9220-2a03e357a5a0.png)
